### PR TITLE
#22 주문 조회 엔티티 컬렉션 조회 최적화

### DIFF
--- a/src/main/java/com/junshock/jpatest/api/OrderApiController.java
+++ b/src/main/java/com/junshock/jpatest/api/OrderApiController.java
@@ -1,0 +1,87 @@
+package com.junshock.jpatest.api;
+
+import com.junshock.jpatest.domain.dto.Address;
+import com.junshock.jpatest.domain.dto.OrderStatus;
+import com.junshock.jpatest.domain.order.Order;
+import com.junshock.jpatest.domain.order.OrderItem;
+import com.junshock.jpatest.repository.OrderRepository;
+import com.junshock.jpatest.repository.OrderSearch;
+import lombok.Data;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderApiController {
+
+    private final OrderRepository orderRepository;
+
+    // Entity를 직접 노출후 호출 하는 방식(확장성 면에서 유연 하지 못하다.)
+    @GetMapping("/api/v1/orders")
+    public List<Order> ordersV1() {
+        List<Order> all = orderRepository.findAllByString(new OrderSearch());
+        for (Order order : all) {
+            order.getMember().getName();
+            order.getDelivery().getAddress();
+
+            List<OrderItem> orderItems = order.getOrderItems();
+            orderItems.stream().forEach(o -> o.getItem().getName());
+        }
+        return all;
+    }
+
+    // DTO로 변환 해서 호출하는 방식, DTO안에 랩핑을 했기 떄문에 부분적 노출임.
+    // DTO 안에 OrderItem 까지도 DTO를 만들어야 노출이 안되고 확장에 유연한 구조임.
+    @GetMapping("/api/v2/orders")
+    public List<OrderDto> ordeersV2(){
+        List<Order> orders = orderRepository.findAllByString(new OrderSearch());
+        List<OrderDto> collect = orders.stream()
+                .map(o -> new OrderDto(o))
+                .collect(Collectors.toList());
+
+        return collect;
+    }
+
+    @Getter
+    static class OrderDto{
+
+        private Long orderId;
+        private String name;
+        private LocalDateTime orderDate;
+        private OrderStatus orderStatus;
+        private Address address;
+        private List<OrderItemDto> orderItems;
+
+        public OrderDto(Order order){
+            orderId = order.getId();
+            name = order.getMember().getName();
+            orderDate = order.getOrderDate();
+            orderStatus = order.getStatus();
+            address = order.getDelivery().getAddress();
+            orderItems = order.getOrderItems().stream()
+                    .map(orderItem -> new OrderItemDto(orderItem))
+                    .collect(Collectors.toList());
+        }
+    }
+
+    @Getter
+    static class OrderItemDto{
+
+        private String itemName; //상품 명
+        private int orderPrice; //주문 가격
+        private int count; //주문 수량
+
+        public OrderItemDto(OrderItem orderItem) {
+            itemName = orderItem.getItem().getName();
+            orderPrice = orderItem.getOrderPrice();
+            count = orderItem.getCount();
+        }
+    }
+
+}

--- a/src/main/java/com/junshock/jpatest/api/OrderApiController.java
+++ b/src/main/java/com/junshock/jpatest/api/OrderApiController.java
@@ -6,6 +6,7 @@ import com.junshock.jpatest.domain.order.Order;
 import com.junshock.jpatest.domain.order.OrderItem;
 import com.junshock.jpatest.repository.OrderRepository;
 import com.junshock.jpatest.repository.OrderSearch;
+import com.junshock.jpatest.repository.order.query.OrderFlatDto;
 import com.junshock.jpatest.repository.order.query.OrderQueryDto;
 import com.junshock.jpatest.repository.order.query.OrderQueryRepository;
 import lombok.Getter;
@@ -91,6 +92,19 @@ public class OrderApiController {
     @GetMapping("/api/v4/orders")
     public List<OrderQueryDto> ordersV4() {
         return orderQueryRepository.findOrderQueryDtos();
+    }
+
+    // 메모리 Map에 collection 들을 저장함으로써 쿼리 횟수를 줄인다.
+    @GetMapping("/api/v5/orders")
+    public List<OrderQueryDto> ordersV5() {
+        return orderQueryRepository.findAllByDto_optimization();
+    }
+
+    // 단일쿼리로 가능하지만 페이징x
+    @GetMapping("/api/v6/orders")
+    public List<OrderFlatDto> ordersV6() {
+        List<OrderFlatDto> flats = orderQueryRepository.findAllByDto_float();
+        return flats;
     }
 
     @Getter

--- a/src/main/java/com/junshock/jpatest/api/OrderApiController.java
+++ b/src/main/java/com/junshock/jpatest/api/OrderApiController.java
@@ -6,6 +6,8 @@ import com.junshock.jpatest.domain.order.Order;
 import com.junshock.jpatest.domain.order.OrderItem;
 import com.junshock.jpatest.repository.OrderRepository;
 import com.junshock.jpatest.repository.OrderSearch;
+import com.junshock.jpatest.repository.order.query.OrderQueryDto;
+import com.junshock.jpatest.repository.order.query.OrderQueryRepository;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,6 +23,7 @@ import java.util.stream.Collectors;
 public class OrderApiController {
 
     private final OrderRepository orderRepository;
+    private final OrderQueryRepository orderQueryRepository;
 
     // Entity를 직접 노출후 호출 하는 방식(확장성 면에서 유연 하지 못하다.)
     @GetMapping("/api/v1/orders")
@@ -81,6 +84,13 @@ public class OrderApiController {
                 .collect(Collectors.toList());
 
         return result;
+    }
+
+    // findOrderQueryDtos 만든 이유는 controller의 OrderDto를 사용하고
+    // repository 참조 하면 의존 관계 순환 오류 가 생기기 떄문에 방지하기 위해서
+    @GetMapping("/api/v4/orders")
+    public List<OrderQueryDto> ordersV4() {
+        return orderQueryRepository.findOrderQueryDtos();
     }
 
     @Getter

--- a/src/main/java/com/junshock/jpatest/api/OrderApiController.java
+++ b/src/main/java/com/junshock/jpatest/api/OrderApiController.java
@@ -9,6 +9,7 @@ import com.junshock.jpatest.repository.OrderSearch;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
@@ -57,6 +58,23 @@ public class OrderApiController {
             // 객체 인스턴스의 참조값 까지 똑같은 중복 데이터 발생
             System.out.println("order ref=" + order + " id=" + order.getId());
         }
+
+        List<OrderDto> result = orders.stream()
+                .map(o -> new OrderDto(o))
+                .collect(Collectors.toList());
+
+        return result;
+    }
+
+    // 네트워크 호출횟수, 전송하는 데이터양은 trade-off 관계
+    // 단쿼리 경우 한방 패치 조인이 낫지만
+    // 한번에 1000개씩 가져올땐 default_batch_fetch_size
+    // 정규화된 db 조회가 나을수 있다. was, db 서버 부하, 메모리도 생각 해야한다.
+    @GetMapping("/api/v3.1/orders")
+    public List<OrderDto> ordersV3_page(
+            @RequestParam(value = "offset", defaultValue = "0") int offset,
+            @RequestParam(value = "limit", defaultValue = "100") int limit) {
+        List<Order> orders = orderRepository.findAllWithMemberDelivery(offset, limit);
 
         List<OrderDto> result = orders.stream()
                 .map(o -> new OrderDto(o))

--- a/src/main/java/com/junshock/jpatest/repository/OrderRepository.java
+++ b/src/main/java/com/junshock/jpatest/repository/OrderRepository.java
@@ -2,7 +2,6 @@ package com.junshock.jpatest.repository;
 
 import com.junshock.jpatest.domain.order.Order;
 import lombok.RequiredArgsConstructor;
-import org.aspectj.weaver.ast.Or;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
@@ -24,7 +23,7 @@ public class OrderRepository {
     }
 
     public List<Order> findAllByString(OrderSearch orderSearch) {
-        // 주문 상태 검색 동적 쿼리(가독성 헤침, 버그 발생 가능성 o)
+        //주문 상태 검색 동적 쿼리(가독성 헤침, 버그 발생 가능성 o)
         //language=JPAQL
         String jpql = "select o From Order o join o.member m";
         boolean isFirstCondition = true;
@@ -66,6 +65,16 @@ public class OrderRepository {
                         " join fetch o.member m" +
                         " join fetch o.delivery d", Order.class
         ).getResultList();
+    }
+
+    public List<Order> findAllWithMemberDelivery(int offset, int limit) {
+        // ToOne 관계는 row수를 증가시키지 않아 페이징 쿼리에 영향을 주지 않는다.
+        // default_batch_fetch_size 영향을 받아서 최적화가 가능하다.
+        return em.createQuery(
+                "select o from Order o", Order.class)
+                .setFirstResult(offset)
+                .setMaxResults(limit)
+                .getResultList();
     }
 
     // join시 n+1 쿼리가 발생한다. (데이터 중복 발생)

--- a/src/main/java/com/junshock/jpatest/repository/order/query/OrderFlatDto.java
+++ b/src/main/java/com/junshock/jpatest/repository/order/query/OrderFlatDto.java
@@ -1,0 +1,31 @@
+package com.junshock.jpatest.repository.order.query;
+
+import com.junshock.jpatest.domain.dto.Address;
+import com.junshock.jpatest.domain.dto.OrderStatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class OrderFlatDto {
+    private Long orderId;
+    private String name;
+    private LocalDateTime orderDate;
+    private OrderStatus orderStatus;
+    private Address address;
+
+    private String itemName;
+    private int orderPrice;
+    private int count;
+
+    public OrderFlatDto(Long orderId, String name, LocalDateTime orderDate, OrderStatus orderStatus, Address address, String itemName, int orderPrice, int count) {
+        this.orderId = orderId;
+        this.name = name;
+        this.orderDate = orderDate;
+        this.orderStatus = orderStatus;
+        this.address = address;
+        this.itemName = itemName;
+        this.orderPrice = orderPrice;
+        this.count = count;
+    }
+}

--- a/src/main/java/com/junshock/jpatest/repository/order/query/OrderItemQueryDto.java
+++ b/src/main/java/com/junshock/jpatest/repository/order/query/OrderItemQueryDto.java
@@ -1,0 +1,19 @@
+package com.junshock.jpatest.repository.order.query;
+
+import lombok.Data;
+
+@Data
+public class OrderItemQueryDto {
+
+    private Long orderId;
+    private String itemName;
+    private int orderPrice;
+    private int count;
+
+    public OrderItemQueryDto(Long orderId, String itemName, int orderPrice, int count) {
+        this.orderId = orderId;
+        this.itemName = itemName;
+        this.orderPrice = orderPrice;
+        this.count = count;
+    }
+}

--- a/src/main/java/com/junshock/jpatest/repository/order/query/OrderQueryDto.java
+++ b/src/main/java/com/junshock/jpatest/repository/order/query/OrderQueryDto.java
@@ -1,0 +1,27 @@
+package com.junshock.jpatest.repository.order.query;
+
+import com.junshock.jpatest.domain.dto.Address;
+import com.junshock.jpatest.domain.dto.OrderStatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+public class OrderQueryDto {
+
+    private Long orderId;
+    private String name;
+    private LocalDateTime orderDate;
+    private OrderStatus orderStatus;
+    private Address address;
+    private List<OrderItemQueryDto> orderItems;
+
+    public OrderQueryDto(Long orderId, String name, LocalDateTime orderDate, OrderStatus orderStatus, Address address) {
+        this.orderId = orderId;
+        this.name = name;
+        this.orderDate = orderDate;
+        this.orderStatus = orderStatus;
+        this.address = address;
+    }
+}

--- a/src/main/java/com/junshock/jpatest/repository/order/query/OrderQueryRepository.java
+++ b/src/main/java/com/junshock/jpatest/repository/order/query/OrderQueryRepository.java
@@ -1,0 +1,54 @@
+package com.junshock.jpatest.repository.order.query;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderQueryRepository {
+
+    private final EntityManager em;
+
+    /**
+     * 주문 조회
+     * Query: 루트 1번, 컬렉션 N번 실행
+     * ToOne(N:1:1:1)관계들을 먼저 조회하고, ToMnay(1:N) 관계는 각각 별도로 처리한다.
+     * 이유는 ToOne관계는 조인해도 row수가 증가하지않는다.
+     * ToMany(1:N)관계는 조인하면 row수가 증가한다.
+     * row 수가 증가하지 않는 ToOne관계는 조인최적화하기 쉬워서 한번조회하고,
+     * ToMany관계는 최적화하기 어려움으로 findOrderItems 메서드로 따로 조회한다.
+     *
+     * @return
+     */
+    public List<OrderQueryDto> findOrderQueryDtos() {
+        List<OrderQueryDto> result = findOrders(); //query N번
+
+        result.forEach(o -> {
+            List<OrderItemQueryDto> orderItems = findOrderItems(o.getOrderId()); //query N번
+            o.setOrderItems(orderItems);
+        });
+        return result;
+    }
+
+    private List<OrderItemQueryDto> findOrderItems(Long orderId) {
+        return em.createQuery(
+                "select new com.junshock.jpatest.repository.order.query.OrderItemQueryDto(oi.order.id, i.name, oi.orderPrice, oi.count)" +
+                        " from OrderItem oi" +
+                        " join oi.item i" +
+                        " where oi.order.id = : orderId", OrderItemQueryDto.class)
+                .setParameter("orderId", orderId)
+                .getResultList();
+    }
+
+    public List<OrderQueryDto> findOrders() {
+        return em.createQuery(
+                "select new com.junshock.jpatest.repository.order.query.OrderQueryDto(o.id, m.name, o.orderDate, o.status, d.address)" +
+                        " from Order o" +
+                        " join o.member m" +
+                        " join o.delivery d", OrderQueryDto.class)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/junshock/jpatest/repository/order/query/OrderQueryRepository.java
+++ b/src/main/java/com/junshock/jpatest/repository/order/query/OrderQueryRepository.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -33,6 +35,34 @@ public class OrderQueryRepository {
         return result;
     }
 
+    public List<OrderQueryDto> findAllByDto_optimization() {
+        List<OrderQueryDto> result = findOrders();
+
+        List<Long> orderIds = result.stream()
+                .map(o -> o.getOrderId())
+                .collect(Collectors.toList());
+
+        Map<Long, List<OrderItemQueryDto>> orderItemMap = findOrderItemMap(orderIds);
+
+        result.forEach(o -> o.setOrderItems(orderItemMap.get(o.getOrderId())));
+
+        return result;
+    }
+
+    private Map<Long, List<OrderItemQueryDto>> findOrderItemMap(List<Long> orderIds) {
+        List<OrderItemQueryDto> orderItems = em.createQuery(
+                "select new com.junshock.jpatest.repository.order.query.OrderItemQueryDto(oi.order.id, i.name, oi.orderPrice, oi.count)" +
+                        " from OrderItem oi" +
+                        " join oi.item i" +
+                        " where oi.order.id in :orderIds", OrderItemQueryDto.class)
+                .setParameter("orderIds", orderIds)
+                .getResultList();
+
+        // 메모리에 맵을 올림으로써 쿼리 횟수를 줄인다.
+        return orderItems.stream()
+                .collect(Collectors.groupingBy(OrderItemQueryDto -> OrderItemQueryDto.getOrderId()));
+    }
+
     private List<OrderItemQueryDto> findOrderItems(Long orderId) {
         return em.createQuery(
                 "select new com.junshock.jpatest.repository.order.query.OrderItemQueryDto(oi.order.id, i.name, oi.orderPrice, oi.count)" +
@@ -49,6 +79,17 @@ public class OrderQueryRepository {
                         " from Order o" +
                         " join o.member m" +
                         " join o.delivery d", OrderQueryDto.class)
+                .getResultList();
+    }
+
+    public List<OrderFlatDto> findAllByDto_float() {
+        return em.createQuery(
+                "select new com.junshock.jpatest.repository.order.query.OrderFlatDto(o.id, m.name, o.orderDate, o.status, d.address, i.name, oi.orderPrice, oi.count)" +
+                        " from Order o" +
+                        " join o.member m" +
+                        " join o.delivery d" +
+                        " join o.orderItems oi" +
+                        " join oi.item i", OrderFlatDto.class)
                 .getResultList();
     }
 }

--- a/src/main/java/com/junshock/jpatest/repository/order/query/OrderQueryRepository.java
+++ b/src/main/java/com/junshock/jpatest/repository/order/query/OrderQueryRepository.java
@@ -35,6 +35,7 @@ public class OrderQueryRepository {
         return result;
     }
 
+    // hibernate.default_batch_fetch_size, @batchsize로 최적화를 안하고 직접 하는 코드
     public List<OrderQueryDto> findAllByDto_optimization() {
         List<OrderQueryDto> result = findOrders();
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
      hibernate:
        show_sql: true
        format_sql: true
+       default_batch_fetch_size: 100 #컬렉션 데이터 쿼리 where 절에 in query 100번 실행 한다. (1:N:M -> 1:1:1)
 
 logging.level:
   org.hibernate.SQL: debug


### PR DESCRIPTION
- 패치조인, distinct 적용하여 중복row를 가져오는 쿼리를 단일 row로 최적화
- distinct 1. db distinct 키워드를 추가한다. 2. entity 중복인경우(객체 인스턴스 동일) 필터한다.
- 패치조인 단점, db의 제약(limit, offset이 없다, appliying in memory 경고)으로 *페이징이 불가
- 1:N DB측 데이터 JPA측에선 예측이 불가하여 메모리 문제 때문에 불가
- 패치조인 페이징이 불가 해결법(컬렉션 엔티티 + 페이징 최적화방법)
1) ToOne 관계를 모두 패치조인으로 변경(member - delievery). 1자로 붙는 형식, rows가 늘지않아 중복데이터 생성x
2) 컬렉션(orderItems) 는 지연로딩으로 조회한다.
3) 지연로딩 성능 최적화를 위해 hibernate.default_batch_fetch_size(글로벌), @BatchSize(개별) 를 적용한다.
이 옵션들을 사용하면 컬렉션이나, 프록시 객체를 한꺼번에 설정한 size 만큼 IN쿼리로 조회한다.
- 단쿼리일 경우 패치조인 유리하지만, 네트워크 호출 횟수, 데이터양에 따라 정규화된 default_batch_fetch_size IN쿼리 최적화가 나을수도 있고 페이징도 가능하다.
