### PR TITLE
#24 OSIV와 성능 최적화

### DIFF
--- a/src/main/java/com/junshock/jpatest/api/OrderApiController.java
+++ b/src/main/java/com/junshock/jpatest/api/OrderApiController.java
@@ -9,6 +9,7 @@ import com.junshock.jpatest.repository.OrderSearch;
 import com.junshock.jpatest.repository.order.query.OrderFlatDto;
 import com.junshock.jpatest.repository.order.query.OrderQueryDto;
 import com.junshock.jpatest.repository.order.query.OrderQueryRepository;
+import com.junshock.jpatest.service.query.OrderQueryService;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,6 +26,7 @@ public class OrderApiController {
 
     private final OrderRepository orderRepository;
     private final OrderQueryRepository orderQueryRepository;
+    private final OrderQueryService orderQueryService;
 
     // Entity를 직접 노출후 호출 하는 방식(확장성 면에서 유연 하지 못하다.)
     @GetMapping("/api/v1/orders")
@@ -50,6 +52,11 @@ public class OrderApiController {
                 .collect(Collectors.toList());
 
         return collect;
+    }
+
+    @GetMapping("/api/v3.0/orders")
+    public List<com.junshock.jpatest.service.query.OrderDto> ordersV3_0() {
+        return orderQueryService.ordersV3();
     }
 
     // 패치조인, distinct 적용하여 중복row를 가져오는 쿼리를 단일 row로 최적화

--- a/src/main/java/com/junshock/jpatest/repository/order/query/OrderQueryRepository.java
+++ b/src/main/java/com/junshock/jpatest/repository/order/query/OrderQueryRepository.java
@@ -35,6 +35,7 @@ public class OrderQueryRepository {
         return result;
     }
 
+    // hibernate.default_batch_fetch_size, @batchsize로 최적화를 안하고 직접 하는 코드
     public List<OrderQueryDto> findAllByDto_optimization() {
         List<OrderQueryDto> result = findOrders();
 

--- a/src/main/java/com/junshock/jpatest/service/query/OrderDto.java
+++ b/src/main/java/com/junshock/jpatest/service/query/OrderDto.java
@@ -1,0 +1,31 @@
+package com.junshock.jpatest.service.query;
+
+import com.junshock.jpatest.domain.dto.Address;
+import com.junshock.jpatest.domain.dto.OrderStatus;
+import com.junshock.jpatest.domain.order.Order;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class OrderDto {
+    private Long orderId;
+    private String name;
+    private LocalDateTime orderDate;
+    private OrderStatus orderStatus;
+    private Address address;
+    private List<OrderItemDto> orderItems;
+
+    public OrderDto(Order order) {
+        orderId = order.getId();
+        name = order.getMember().getName();
+        orderDate = order.getOrderDate();
+        orderStatus = order.getStatus();
+        address = order.getDelivery().getAddress();
+        orderItems = order.getOrderItems().stream()
+                .map(orderItem -> new OrderItemDto(orderItem))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/junshock/jpatest/service/query/OrderItemDto.java
+++ b/src/main/java/com/junshock/jpatest/service/query/OrderItemDto.java
@@ -1,0 +1,17 @@
+package com.junshock.jpatest.service.query;
+
+import com.junshock.jpatest.domain.order.OrderItem;
+import lombok.Getter;
+
+@Getter
+public class OrderItemDto {
+    private String itemName; //상품 명
+    private int orderPrice; //주문 가격
+    private int count; //주문 수량
+
+    public OrderItemDto(OrderItem orderItem) {
+        itemName = orderItem.getItem().getName();
+        orderPrice = orderItem.getOrderPrice();
+        count = orderItem.getCount();
+    }
+}

--- a/src/main/java/com/junshock/jpatest/service/query/OrderQueryService.java
+++ b/src/main/java/com/junshock/jpatest/service/query/OrderQueryService.java
@@ -1,0 +1,28 @@
+package com.junshock.jpatest.service.query;
+
+import com.junshock.jpatest.domain.order.Order;
+import com.junshock.jpatest.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OrderQueryService {
+
+    private final OrderRepository orderRepository;
+
+    public List<OrderDto> ordersV3() {
+        List<Order> orders = orderRepository.findAllWithItem();
+
+        List<OrderDto> result = orders.stream()
+                .map(o -> new OrderDto(o))
+                .collect(Collectors.toList());
+
+        return result;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,9 @@ spring:
        show_sql: true
        format_sql: true
        default_batch_fetch_size: 100 #컬렉션 데이터 쿼리 where 절에 in query 100번 실행 한다. (1:N:M -> 1:1:1)
-
+   open-in-view: false #OSIV를 끄면 트랜잭션을 종료할 떄 영속성 컨텍스트를 닫고, DB 커넥션도 반환한다. 따라서 *커넥션 리소스를 낭비하지 않는다.
+   #v1, getName하는순간 프록시 초기화를 해야하는데 영속선컨텍스트가 트랜잭션에만 있어서 아래와같은 에러발생. 트랜잭션 안에 로딩 or 페치조인 사용
+   #"message": "could not initialize proxy [com.junshock.jpatest.domain.Member#1] - no Session",
 logging.level:
   org.hibernate.SQL: debug
   org.hibernate.type: trace


### PR DESCRIPTION
- open-in-view 설정에 따라 jpa가 영속선 컨텍스트 라이프 사이클을 mvc단 까지 관리하냐,
트랜잭션(Service,Repository) 까지만 관리하냐 를 설정할 수 있다.
- 고객서비스의 실시간 APIS느 OSIV를 끈다. ADMIN처럼 커넥션 많이 사용하지 않는곳에서는 OSIV를 켠다.